### PR TITLE
Calendar pane of start menu now comes from right

### DIFF
--- a/src/components/start/searchpane.scss
+++ b/src/components/start/searchpane.scss
@@ -88,7 +88,7 @@
 
   &[data-hide="true"] {
     bottom: 10px;
-    transform: translateY(120%);
+    transform: translateX(120%);
   }
 }
 


### PR DESCRIPTION
Calendar pane of start menu now comes from right like in actual win11 instead from bottom